### PR TITLE
Fix inconsistent use of backup and backups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN chmod +x /restore.sh
 COPY backup.sh /backup.sh
 RUN chmod +x /backup.sh
 
-RUN mkdir /backup
+RUN mkdir /backups
 RUN mkdir /cacti
 RUN mkdir /spine
 

--- a/README.md
+++ b/README.md
@@ -112,12 +112,12 @@ This will store compressed backups in a tar.gz format within the cacti docker co
 ### Restore Backup
 To restore from an existing backup, run the following docker exec command with the backup file location as an argument.
 ```
-docker exec <docker image ID or name> ./restore.sh /backup/<filename>
+docker exec <docker image ID or name> ./restore.sh /backups/<filename>
 ```
 
 To get a list of backups, the following command should display them:
 ```
-docker exec <docker image ID or name> ls /backup
+docker exec <docker image ID or name> ls /backups
 ```
 
 ### Updating Cacti

--- a/backup.sh
+++ b/backup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Script is to backup cacti files and settings. This will store files in /backup on the container and will store the following in a compressed file
+# Script is to backup cacti files and settings. This will store files in /backups on the container and will store the following in a compressed file
 # - Cacti SQL Database
 # - Cacti Plugins
 # - Cacti RRD files, the graphs that make it all pretty :)
@@ -26,15 +26,15 @@ mysqldump -h ${DB_HOST} -u${DB_USER} -p${DB_PASS} ${DB_NAME} > /tmp/backup/cacti
 echo "$(date +%F_%R) [Backup] Compressing backup files."
 tar -zcf $(date +%Y%m%d_%H%M%S)_cactibackup.tar.gz -C /tmp/backup/ . > /dev/null 2>&1
 
-# make sure backup directory exists, if not make it
-if [ ! -d "/backup" ]; then
-echo "$(date +%F_%R) [Backup] Backup directory does not exists, creating new one."
-  mkdir /backup
+# make sure backups directory exists, if not make it
+if [ ! -d "/backups" ]; then
+echo "$(date +%F_%R) [Backup] Backups directory does not exists, creating new one."
+  mkdir /backups
 fi
 
-# move compressed backup to /backup directory
-echo "$(date +%F_%R) [Backup] Moving backup files to /backup."
-mv *_cactibackup.tar.gz /backup
+# move compressed backup file to /backups directory
+echo "$(date +%F_%R) [Backup] Moving backup files to /backups."
+mv *_cactibackup.tar.gz /backups
 
 # remove temporary backup workspace
 echo "$(date +%F_%R) [Backup] Cleaning up temporary files."
@@ -45,7 +45,7 @@ echo "$(date +%F_%R) [Backup] Removing backup files if more then ${BACKUP_RETENT
 
 # adding 1 to BACKUP_RETENTION for delete statement to work correctly, then remove any additional
 x=$((${BACKUP_RETENTION}+1))
-rm -f $(ls -1t /backup/*_cactibackup.tar.gz | tail -n +$x)
+rm -f $(ls -1t /backups/*_cactibackup.tar.gz | tail -n +$x)
 
 # write note in cacti.log that a backup is complete
 echo "$(date +%F_%R) [Backup] Cacti Backup Complete!" >> /cacti/log/cacti.log


### PR DESCRIPTION
Proposed fix to address #45 
Where docker compose files map in `/backups` yet `backup.sh` expects to use `/backup`
As the directory contains multiple files, the plural would make more sense. IMHO