### PR TITLE
Fix #52

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ REPLACE INTO `%DB_NAME%`.`settings` (`name`, `value`) VALUES('poller_type', '2')
 ```
 
 # Change Log
+#### 1.2.6a - 10/30/2019
+ * Update start.sh to persist Apache Cacti configurations on restart. [#52] (https://github.com/scline/docker-cacti/issues/52)
+ * Update docker-compose examples to use different type of volumes so `docker-compose down` will not affect data without the `-v` flag.
+
 #### 1.2.6 - 09/06/2019
  * Update Cacti and Spine from 1.2.0 to 1.2.6
    * [changelog][cacti_changelog]

--- a/docker-compose/cacti_multi.yml
+++ b/docker-compose/cacti_multi.yml
@@ -14,6 +14,9 @@ services:
       - DB_ROOT_PASS=rootpassword
       - INITIALIZE_DB=1
       - TZ=America/Los_Angeles
+    volumes:
+      - cacti-master-data:/cacti
+      - cacti-master-backups:/backups
     links:
       - db-master
 
@@ -37,6 +40,9 @@ services:
       - REMOTE_POLLER=1
       - INITIALIZE_DB=1
       - TZ=America/Los_Angeles
+    volumes:
+      - cacti-poller-data:/cacti
+      - cacti-poller-backups:/backups
     links:
       - db-poller
 
@@ -61,6 +67,8 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=rootpassword
       - TZ=America/Los_Angeles
+    volumes:
+      - cacti-db-master:/var/lib/mysql
 
   db-poller:
     image: "percona:5.7.14"
@@ -81,3 +89,13 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=rootpassword
       - TZ=America/Los_Angeles
+    volumes:
+      - cacti-db-poller:/var/lib/mysql
+
+volumes:
+  cacti-db-master:
+  cacti-db-poller:
+  cacti-master-data:
+  cacti-master-backups:
+  cacti-poller-data:
+  cacti-poller-backups:

--- a/docker-compose/cacti_multi_shared.yml
+++ b/docker-compose/cacti_multi_shared.yml
@@ -14,6 +14,9 @@ services:
       - DB_ROOT_PASS=rootpassword
       - INITIALIZE_DB=1
       - TZ=America/Los_Angeles
+    volumes:
+      - cacti-master-data:/cacti
+      - cacti-master-backups:/backups
     links:
       - db
 
@@ -37,6 +40,9 @@ services:
       - REMOTE_POLLER=1
       - INITIALIZE_DB=1
       - TZ=America/Los_Angeles
+    volumes:
+      - cacti-poller-data:/cacti
+      - cacti-poller-backups:/backups
     links:
       - db
 
@@ -61,3 +67,12 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=rootpassword
       - TZ=America/Los_Angeles
+    volumes:
+      - cacti-db:/var/lib/mysql
+
+volumes:
+  cacti-db:
+  cacti-master-data:
+  cacti-master-backups:
+  cacti-poller-data:
+  cacti-poller-backups:

--- a/docker-compose/cacti_single_install.yml
+++ b/docker-compose/cacti_single_install.yml
@@ -15,8 +15,8 @@ services:
       - INITIALIZE_DB=1
       - TZ=America/Los_Angeles
     volumes:
-      - /docker/cacti:/cacti
-      - /docker/backups:/backups
+      - cacti-data:/cacti
+      - cacti-backups:/backups
     links:
       - db
   db:
@@ -40,3 +40,9 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=rootpassword
       - TZ=America/Los_Angeles
+    volumes:
+      - cacti-db/var/lib/mysql
+volumes:
+  cacti-db:
+  cacti-data:
+  cacti-backups:

--- a/docker-compose/cacti_testing.yml
+++ b/docker-compose/cacti_testing.yml
@@ -17,8 +17,8 @@ services:
       - INITIALIZE_DB=1
       - TZ=America/Los_Angeles
     volumes:
-      - ~/docker/cacti:/cacti
-      - ~/docker/backups:/backups
+      - cacti-data:/cacti
+      - cacti-backups:/backups
     links:
       - db
   db:
@@ -42,3 +42,9 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=rootpassword
       - TZ=America/Los_Angeles
+    volumes:
+      - cacti-db:/var/lib/mysql
+volumes:
+  cacti-db:
+  cacti-data:
+  cacti-backups:

--- a/start.sh
+++ b/start.sh
@@ -110,6 +110,15 @@ if [ ! -f /cacti/install.lock ]; then
     echo "$(date +%F_%R) [New Install] Creating lock file, db setup complete."
 fi
 
+# copy configuration files in the event /cacti is being shared as a volume
+echo "$(date +%F_%R) [Apache] Validating httpd cacti configuration is present."
+if [ -f "/etc/httpd/conf.d/cacti.conf" ]; then
+    echo "$(date +%F_%R) [Apache] /etc/httpd/conf.d/cacti.conf exist, nothing to do."
+else 
+    echo "$(date +%F_%R) [Apache] /etc/httpd/conf.d/cacti.conf does not exist, copying a new one over."
+    cp /template_configs/cacti.conf /etc/httpd/conf.d/
+fi
+
 # correcting file permissions
 echo "$(date +%F_%R) [Note] Setting cacti file permissions."
 chown -R apache.apache /cacti/resource/


### PR DESCRIPTION
 * Update start.sh to persist Apache Cacti configurations on restart. [#52] (https://github.com/scline/docker-cacti/issues/52)
 * Update docker-compose examples to use different type of volumes so `docker-compose down` will not affect data without the `-v` flag.
