### PR TITLE
Added missing ':' in single server composer file.

### DIFF
--- a/docker-compose/cacti_single_install.yml
+++ b/docker-compose/cacti_single_install.yml
@@ -41,7 +41,7 @@ services:
       - MYSQL_ROOT_PASSWORD=rootpassword
       - TZ=America/Los_Angeles
     volumes:
-      - cacti-db/var/lib/mysql
+      - cacti-db:/var/lib/mysql
 volumes:
   cacti-db:
   cacti-data:


### PR DESCRIPTION
I noticed when running 'docker-compose down -v' that docker complained that the cacti-db volume didn't exist. Adding the ':' to the composer file resolved the issue.