### PR TITLE
Delete http.pid before starting apache

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -151,4 +151,5 @@ snmpd -Lf /var/log/snmpd.log &
 
 # start web service
 echo "$(date +%F_%R) [Note] Starting httpd service."
+rm -rf /run/httpd/httpd.pid
 httpd -DFOREGROUND


### PR DESCRIPTION
Sometimes the server cannot start because the apache PID exists with error message:
`httpd (pid 26) already running`

This happens when the docker instance has unexpectedly restarted.